### PR TITLE
required_keywords macro should return the expression

### DIFF
--- a/src/RequiredKeywords.jl
+++ b/src/RequiredKeywords.jl
@@ -23,6 +23,7 @@ module RequiredKeywords
     keywords must always be specified. If they are not, a `UnassignedKeyword` exception is thrown.
     """
     macro required_keywords(exp)
+        exp
     end
 
     macro showexp(exp)


### PR DESCRIPTION
This seems pretty essential for having this macro have no effect on julia 0.7 and higher ...